### PR TITLE
Renamed package and adjusted README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Both of the above modules are extremely useful when interacting with Slopes as t
 
 Slopes is available for install via `npm`:
 
-`npm install --save slopes`
+`npm install --save @avalabs/slopes`
 
 You can also pull the repo down directly and build it from scratch:
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "slopes",
+  "name": "@avalabs/slopes",
   "version": "1.4.3",
   "description": "AVA Platform JS Library",
   "main": "typings/src/index.js",


### PR DESCRIPTION
This PR is to rename the `slopes` package to`@avalabs/slopes` on npm.