### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,10 +131,10 @@ let newAddress2 = myKeychain.importKey(mypk); //returns a Buffer for the address
 The AVMKeyChain extends the global KeyChain class, which has standardized key management capabilities. The following functions are available on any keychain that implements this interface.
 
 ```js
-let addresses = avm.keyChain().getAddresses(); //returns an array of Buffers for the addresses
-let addressStrings = avm.keyChain().getAddressStrings(); //returns an array of strings for the addresses
-let exists = myKeychain.hasKey(myaddress); //returns true if the address is managed
-let keypair = myKeychain.getKey(myaddress); //returns the keypair class
+let addresses = myKeychain.getAddresses(); //returns an array of Buffers for the addresses
+let addressStrings = myKeychain.getAddressStrings(); //returns an array of strings for the addresses
+let exists = myKeychain.hasKey(newAddress1); //returns true if the address is managed
+let keypair = myKeychain.getKey(newAddress1); //returns the keypair class
 ```
 
 ### Working with keypairs
@@ -156,10 +156,10 @@ keypair.generateKey(); //creates a new random keypair
 let mypk = "24jUJ9vZexUM6expyMcT48LBx27k1m7xpraoV62oSQAHdziao5";
 let successul = keypair.importKey(mypk); //returns boolean if private key imported successfully
 
-let message = "Wubalubadubdub";
+let message = Buffer.from("Wubalubadubdub");
 let signature = keypair.sign(message); //returns a Buffer with the signature
 let signerPubk = keypair.recover(message, signature);
-let isValid = keypair.verify(message, signature, signerPubk); //returns a boolean
+let isValid = keypair.verify(message, signature); //returns a boolean
 ```
 
 ## Example 2 &mdash; Creating An Asset
@@ -318,7 +318,7 @@ let friendsAddress = "X-B6D4v1VtPYLbiUvYXtW4Px8oE9imC2vGW"; //AVA serialized add
 //   * An array of addresses sending the funds
 //   * An array of addresses any leftover funds are sent
 //   * The AssetID of the funds being sent
-let unsignedTx = avm.makeUnsignedTx(utxos, amount, [friendsAddress], myAddresses, myAddresses, assetid); 
+let unsignedTx = avm.makeUnsignedTx(utxos, amount, [friendsAddress], myAddresses, myAddresses, assetid);
 let signedTx = avm.signTx(unsignedTx);
 let txid = await avm.issueTx(signedTx);
 ```

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Slopes is a JavaScript Library for interfacing with the AVA Platform. It is built using TypeScript and intended to support both browser and Node.js. The Slopes library allows one to issue commands to the AVA node APIs. 
+Slopes is a JavaScript Library for interfacing with the AVA Platform. It is built using TypeScript and intended to support both browser and Node.js. The Slopes library allows one to issue commands to the AVA node APIs.
 
 The APIs currently supported by default are:
 
@@ -13,7 +13,7 @@ The APIs currently supported by default are:
 
 ## Getting Started
 
-We built Slopes with ease of use in mind. With this library, any Javascript developer is able to interact with a node on the AVA Platform who has enabled their API endpoints for the developer's consumption. We keep the library up-to-date with the latest changes in the [AVA Platform Specification](https://avalabs.org/docs/). 
+We built Slopes with ease of use in mind. With this library, any Javascript developer is able to interact with a node on the AVA Platform who has enabled their API endpoints for the developer's consumption. We keep the library up-to-date with the latest changes in the [AVA Platform Specification](https://avalabs.org/docs/).
 
   Using Slopes, developers are able to:
 
@@ -174,7 +174,7 @@ let avm = ava.AVM(); //returns a reference to the AVM API used by Slopes
 
 ### Describe the new asset
 
-The first steps in creating a new asset using Slopes is to determine the qualties of the asset. We will give the asset a name, a ticker symbol, as well as a denomination. 
+The first steps in creating a new asset using Slopes is to determine the qualties of the asset. We will give the asset a name, a ticker symbol, as well as a denomination.
 
 ```js
 // The fee to pay for the asset, we assume this network is fee-less
@@ -191,7 +191,7 @@ let denomination = 9;
 
 ### Creating the initial state
 
-We want to mint an asset with 400 coins to all of our managed keys, 500 to the second address we know of, and 600 to the second and third address. This sets up the state that will result from the Create Asset transaction. 
+We want to mint an asset with 400 coins to all of our managed keys, 500 to the second address we know of, and 600 to the second and third address. This sets up the state that will result from the Create Asset transaction.
 
 *Note: This example assumes we have the keys already managed in our AVM Keychain.*
 
@@ -215,7 +215,7 @@ initialState.addOutput(secpbase3, slopes.AVMConstants.SECPFXID);
 
 ### Creating the signed transaction
 
-Now that we know what we want an asset to look like, we create an output to send to the network. There is an AVM helper function `makeCreateAssetTx()` which does just that. 
+Now that we know what we want an asset to look like, we create an output to send to the network. There is an AVM helper function `makeCreateAssetTx()` which does just that.
 
 ```js
 // Fetch the UTXOSet for our addresses
@@ -229,7 +229,7 @@ let signed = avm.keyChain().signTx(unsigned); //returns a Tx class
 
 ### Issue the signed transaction
 
-Now that we have a signed transaction ready to send to the network, let's issue it! 
+Now that we have a signed transaction ready to send to the network, let's issue it!
 
 Using the Slopes AVM API, we going to call the issueTx function. This function can take either the Tx class returned in the previous step, a base-58 string AVA serialized representation of the transaction, or a raw Buffer class with the data for the transaction. Examples of each are below:
 
@@ -256,7 +256,7 @@ Now that we sent the transaction to the network, it takes a few seconds to deter
 
 ```js
 // returns one of: "Accepted", "Processing", "Unknown", and "Rejected"
-let status = await avm.getTxStatus(txid); 
+let status = await avm.getTxStatus(txid);
 ```
 
 The statuses can be one of "Accepted", "Processing", "Unknown", and "Rejected":
@@ -271,6 +271,7 @@ The statuses can be one of "Accepted", "Processing", "Unknown", and "Rejected":
 The AVM uses the TxID of the transaction which created the asset as the unique identifier for the asset. This unique identifier is henceforth known as the "AssetID" of the asset. When assets are traded around the AVM, they always reference the AssetID that they represent.
 
 ## Example 3 &mdash; Sending An Asset
+
 This example sends an asset in the AVM to a single recipient. The first step in this process is to create an instance of Slopes connected to our AVA Platform endpoint of choice.
 
 ```js
@@ -283,11 +284,11 @@ We're also assuming that the keystore contains a list of addresses used in this 
 
 ### Getting the UTXO Set
 
-The AVM stores all available balances in a datastore called Unspent Transaction Outputs (UTXOs). A UTXO Set is the unique list of outputs produced by transactions, addresses that can spend those outputs, and other variables such as lockout times (a timestamp after which the output can be spent) and thresholds (how many signers are required to spend the output). 
+The AVM stores all available balances in a datastore called Unspent Transaction Outputs (UTXOs). A UTXO Set is the unique list of outputs produced by transactions, addresses that can spend those outputs, and other variables such as lockout times (a timestamp after which the output can be spent) and thresholds (how many signers are required to spend the output).
 
-For the case of this example, we're going to create a simple transaction that spends an amount of available coins and sends it to a single address without any restrictions. The management of the UTXOs will mostly be abstracted away. 
+For the case of this example, we're going to create a simple transaction that spends an amount of available coins and sends it to a single address without any restrictions. The management of the UTXOs will mostly be abstracted away.
 
-However, we do need to get the UTXO Set for the addresses we're managing. 
+However, we do need to get the UTXO Set for the addresses we're managing.
 
 ```js
 let myAddresses = avm.keyChain().getAddresses(); //returns an array of addresses the keychain manages
@@ -302,6 +303,7 @@ The `makeUnsignedTx()` helper function sends a single asset type. We have a part
 let assetid = "23wKfz3viWLmjWo2UZ7xWegjvnZFenGAVkouwQCeB9ubPXodG6"; //avaSerialized string
 let mybalance = utxos.getBalance(myAddresses, assetid); //returns 400 as a BN
 ```
+
 We have 400 coins! We're going to now send 100 of those coins to our friend's address.
 
 ```js
@@ -329,7 +331,7 @@ Now that we sent the transaction to the network, it takes a few seconds to deter
 
 ```js
 // returns one of: "Accepted", "Processing", "Unknown", and "Rejected"
-let status = await avm.getTxStatus(txid); 
+let status = await avm.getTxStatus(txid);
 ```
 
 The statuses can be one of "Accepted", "Processing", "Unknown", and "Rejected":
@@ -341,7 +343,7 @@ The statuses can be one of "Accepted", "Processing", "Unknown", and "Rejected":
 
 ### Check the results
 
-The transaction finally came back as "Accepted", now let's update the UTXOSet and verify that the transaction balance is as we expected. 
+The transaction finally came back as "Accepted", now let's update the UTXOSet and verify that the transaction balance is as we expected.
 
 *Note: In a real network the balance isn't guaranteed to match this scenario. Transaction fees or additional spends may vary the balance. For the purpose of this example, we assume neither of those cases.*
 


### PR DESCRIPTION
Working my way through the docs and making changes to the docs as needed.

## TLDR

* Use `myKeychain` var instead of calling `keyChain()`.
* Pass in proper var to `hasKey` and `getKey`.
* Create `Buffer` of message.
* Fix `verify` call by removing passed in `signerPubk`.
* Remove extra characters at end of lines

### Use `myKeychain` var instead of calling `keyChain()`

Since we're already assigning the result of `avm.keyChain()` to the `myKeychain` above it seems cleaner to just use that var throughout the examples. This is just personal preference. 

### Pass in proper var to `hasKey` and `getKey`

The existing example is passing a nonexistent `myaddress` var to `hasKey` and `getKey`

```js
let exists = myKeychain.hasKey(myaddress); //returns true if the address is managed
let keypair = myKeychain.getKey(myaddress); //returns the keypair class
```

This update passes in the `newAddress1` var which is created earlier in the README.

### Create `Buffer` of message

[`keypair.sign`](https://github.com/ava-labs/slopes/blob/master/src/apis/avm/keychain.ts#L156) accepts a `Buffer` as an argument. The current README is passing in a `string` which is incorrect. This update creates a Buffer out of the `message` var.

### Fix `verify` call by removing passed in `signerPubk`

[`keypair.verify`](https://github.com/ava-labs/slopes/blob/master/src/apis/avm/keychain.ts#L174) only accepts 2 arguments. This PR removes the 3rd `signerPubk` arg

### Remove extra characters at end of lines

I use [Markdown lint](https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint) and it's complaining about extra characters at the end of lines.