### PR TITLE
Syntax updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ let utxos = await avm.getUTXOs(myAddresses);
 
 ### Spending the UTXOs
 
-The `makeUnsignedTx()` helper function sends a single asset type. We have a particular assetID whose coins we want to send to a recipient address. This is an imaginary asset for this example which we believe to have 400 coins. Let's verify that we have the funds available for the transaction.
+The `makeBaseTx()` helper function sends a single asset type. We have a particular assetID whose coins we want to send to a recipient address. This is an imaginary asset for this example which we believe to have 400 coins. Let's verify that we have the funds available for the transaction.
 
 ```js
 let assetid = "23wKfz3viWLmjWo2UZ7xWegjvnZFenGAVkouwQCeB9ubPXodG6"; //avaSerialized string
@@ -319,7 +319,7 @@ let friendsAddress = "X-B6D4v1VtPYLbiUvYXtW4Px8oE9imC2vGW"; //AVA serialized add
 //   * An array of addresses sending the funds
 //   * An array of addresses any leftover funds are sent
 //   * The AssetID of the funds being sent
-let unsignedTx = await avm.makeUnsignedTx(utxos, sendAmount, [friendsAddress], addressStrings, addressStrings, assetid);
+let unsignedTx = await avm.makeBaseTx(utxos, sendAmount, [friendsAddress], addressStrings, addressStrings, assetid);
 let signedTx = avm.signTx(unsignedTx);
 let txid = await avm.issueTx(signedTx);
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "slopes",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "AVA Platform JS Library",
   "main": "typings/src/index.js",
   "types": "typings/src/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "slopes",
-  "version": "1.7.2",
+  "version": "1.7.1",
   "description": "AVA Platform JS Library",
   "main": "typings/src/index.js",
   "types": "typings/src/index.d.ts",

--- a/src/apis/avm/api.ts
+++ b/src/apis/avm/api.ts
@@ -596,9 +596,9 @@ class AVMAPI extends JRPCAPI{
         changeAddresses:Array<string>, assetID:Buffer | string = undefined, asOf:BN = UnixNow(), 
         locktime:BN = new BN(0), threshold:number = 1
     ):Promise<UnsignedTx> => {
-        let to:Array<Buffer> = this._cleanAddressArray(toAddresses, "makeUnsignedTx").map(a => bintools.stringToAddress(a));;
-        let from:Array<Buffer> = this._cleanAddressArray(fromAddresses, "makeUnsignedTx").map(a => bintools.stringToAddress(a));;
-        let change:Array<Buffer> = this._cleanAddressArray(changeAddresses, "makeUnsignedTx").map(a => bintools.stringToAddress(a));;
+        let to:Array<Buffer> = this._cleanAddressArray(toAddresses, "makeBaseTx").map(a => bintools.stringToAddress(a));;
+        let from:Array<Buffer> = this._cleanAddressArray(fromAddresses, "makeBaseTx").map(a => bintools.stringToAddress(a));;
+        let change:Array<Buffer> = this._cleanAddressArray(changeAddresses, "makeBaseTx").map(a => bintools.stringToAddress(a));;
 
         if(typeof assetID === "string"){
             assetID = bintools.avaDeserialize(assetID);
@@ -694,7 +694,7 @@ class AVMAPI extends JRPCAPI{
     /**
      * Helper function which takes an unsigned transaction and signs it, returning the resulting [[Tx]].
      * 
-     * @param utx The unsigned transaction of type [[TxUnsigned]]
+     * @param utx The unsigned transaction of type [[UnsignedTx]]
      * 
      * @returns A signed transaction of type [[Tx]]
      */

--- a/src/apis/avm/utxos.ts
+++ b/src/apis/avm/utxos.ts
@@ -541,7 +541,7 @@ export class UTXOSet {
         initialState:InitialStates, name:string, 
         symbol:string, denomination:number
     ):UnsignedTx => {
-        // Cheating and using makeUnsignedTx to get Ins and Outs for fees.
+        // Cheating and using makeBaseTx to get Ins and Outs for fees.
         // Fees are burned, so no toAddresses, only fromAddresses and changeAddresses, both are the feeSenderAddresses
         let utx:UnsignedTx = this.makeBaseTx(networkid, blockchainid, fee, [], feeSenderAddresses, feeSenderAddresses, avaAssetID);
         let ins:Array<TransferableInput> = utx.getTransaction().getIns();


### PR DESCRIPTION
* Rename remaining `makeUnsignedTx` calls to `makeBaseTx` and confirm they're returning `UnsignedTx` instead of `TxUnsigned`