### PR TITLE
fix: Typo `usermame` => `username`

### DIFF
--- a/src/apis/keystore/api.ts
+++ b/src/apis/keystore/api.ts
@@ -62,7 +62,7 @@ class KeystoreAPI extends JRPCAPI{
      */
     importUser = async (username:string, user:string, password:string):Promise<boolean> => {
         let params = {
-            "usermame": username,
+            "username": username,
             "user": user,
             "password": password
         };


### PR DESCRIPTION
Linked to issue #35 .

Typo in params of the 'importUser' call .