### PR TITLE
fix: Implement `importKey` , `exportKey` for platformAPI

### DIFF
--- a/src/apis/platform/api.ts
+++ b/src/apis/platform/api.ts
@@ -438,6 +438,46 @@ class PlatformAPI extends JRPCAPI{
     }
 
     /**
+     * Exports the private key for an address.
+     *
+     * @param username The name of the user with the private key
+     * @param password The password used to decrypt the private key
+     * @param address The address whose private key should be exported
+     *
+     * @returns Promise with the decrypted private key as store in the database
+     */
+    exportKey = async (username:string, password:string, address:string):Promise<string> => {
+        let params = {
+            "username": username,
+            "password": password,
+            "address": address
+        };
+        return this.callMethod("platform.exportKey", params).then((response:RequestResponseData) => {
+            return response.data["result"]["privateKey"];
+        });
+    }
+
+    /**
+     * Give a user control over an address by providing the private key that controls the address.
+     *
+     * @param username The name of the user to store the private key
+     * @param password The password that unlocks the user
+     * @param privateKey A string representing the private key in the vm's format
+     *
+     * @returns The address for the imported private key.
+     */
+    importKey = async (username:string, password:string, privateKey:string):Promise<string> => {
+        let params = {
+            "username": username,
+            "password": password,
+            "privateKey": privateKey
+        };
+        return this.callMethod("platform.importKey", params).then((response:RequestResponseData) => {
+            return response.data["result"]["address"];
+        });
+    }
+
+    /**
      * This class should not be instantiated directly. Instead use the [[Slopes.addAPI]] method.
      * 
      * @param core A reference to the Slopes class

--- a/tests/apis/platform/api.test.ts
+++ b/tests/apis/platform/api.test.ts
@@ -1,9 +1,9 @@
 import mockAxios from 'jest-mock-axios';
 
 
-import {Slopes} from "src";
+import { Slopes } from "src";
 import PlatformAPI from "src/apis/platform/api";
-import {Buffer} from "buffer/";
+import { Buffer } from "buffer/";
 import BN from "bn.js";
 import BinTools from 'src/utils/bintools';
 
@@ -20,8 +20,8 @@ describe("Platform", () => {
     let username = 'AvaLabs';
     let password = 'password';
 
-    let slopes = new Slopes(ip, port, protocol, 12345, undefined, true);
-    let platform: PlatformAPI;
+    let slopes = new Slopes(ip,port,protocol, 12345, undefined, true);
+    let platform:PlatformAPI;
 
     beforeAll(() => {
         platform = new PlatformAPI(slopes);
@@ -31,13 +31,13 @@ describe("Platform", () => {
         mockAxios.reset();
     });
 
-    test("createBlockchain 1", async () => {
-        let blockchainID: string = "7sik3Pr6r1FeLrvK1oWwECBS8iJ5VPuSh";
-        let vmID: string = "7sik3Pr6r1FeLrvK1oWwECBS8iJ5VPuSh";
-        let name: string = "Some Blockchain";
-        let genesis: string = '{ruh:"roh"}';
-        let result: Promise<string> = platform.createBlockchain(vmID, name, 1, genesis);
-        let payload: object = {
+    test("createBlockchain 1", async ()=>{
+        let blockchainID:string = "7sik3Pr6r1FeLrvK1oWwECBS8iJ5VPuSh";
+        let vmID:string = "7sik3Pr6r1FeLrvK1oWwECBS8iJ5VPuSh";
+        let name:string = "Some Blockchain";
+        let genesis:string = '{ruh:"roh"}';
+        let result:Promise<string> = platform.createBlockchain(vmID, name, 1, genesis);
+        let payload:object = {
             "result": {
                 "blockchainID": blockchainID
             }
@@ -47,20 +47,20 @@ describe("Platform", () => {
         };
 
         mockAxios.mockResponse(responseObj);
-        let response: string = await result;
+        let response:string = await result;
 
         expect(mockAxios.request).toHaveBeenCalledTimes(1);
         expect(response).toBe(blockchainID);
     });
 
-    test("createBlockchain 2", async () => {
-        let blockchainID: string = "7sik3Pr6r1FeLrvK1oWwECBS8iJ5VPuSh";
-        let vmID: string = "7sik3Pr6r1FeLrvK1oWwECBS8iJ5VPuSh";
-        let name: string = "Some Blockchain";
-        let genesis: string = '{ruh:"roh"}';
-        let subnetID: string = "abcdefg";
-        let result: Promise<string> = platform.createBlockchain(vmID, name, 1, genesis, subnetID);
-        let payload: object = {
+    test("createBlockchain 2", async ()=>{
+        let blockchainID:string = "7sik3Pr6r1FeLrvK1oWwECBS8iJ5VPuSh";
+        let vmID:string = "7sik3Pr6r1FeLrvK1oWwECBS8iJ5VPuSh";
+        let name:string = "Some Blockchain";
+        let genesis:string = '{ruh:"roh"}';
+        let subnetID:string = "abcdefg";
+        let result:Promise<string> = platform.createBlockchain(vmID, name, 1, genesis, subnetID);
+        let payload:object = {
             "result": {
                 "blockchainID": blockchainID
             }
@@ -70,20 +70,20 @@ describe("Platform", () => {
         };
 
         mockAxios.mockResponse(responseObj);
-        let response: string = await result;
+        let response:string = await result;
 
         expect(mockAxios.request).toHaveBeenCalledTimes(1);
         expect(response).toBe(blockchainID);
     });
 
-    test("createBlockchain 3", async () => {
-        let blockchainID: string = "7sik3Pr6r1FeLrvK1oWwECBS8iJ5VPuSh";
-        let vmID: string = "7sik3Pr6r1FeLrvK1oWwECBS8iJ5VPuSh";
-        let name: string = "Some Blockchain";
-        let genesis: string = '{ruh:"roh"}';
-        let subnetID: Buffer = Buffer.from("abcdef", "hex");
-        let result: Promise<string> = platform.createBlockchain(vmID, name, 1, genesis, subnetID);
-        let payload: object = {
+    test("createBlockchain 3", async ()=>{
+        let blockchainID:string = "7sik3Pr6r1FeLrvK1oWwECBS8iJ5VPuSh";
+        let vmID:string = "7sik3Pr6r1FeLrvK1oWwECBS8iJ5VPuSh";
+        let name:string = "Some Blockchain";
+        let genesis:string = '{ruh:"roh"}';
+        let subnetID:Buffer = Buffer.from("abcdef", "hex");
+        let result:Promise<string> = platform.createBlockchain(vmID, name, 1, genesis, subnetID);
+        let payload:object = {
             "result": {
                 "blockchainID": blockchainID
             }
@@ -93,17 +93,17 @@ describe("Platform", () => {
         };
 
         mockAxios.mockResponse(responseObj);
-        let response: string = await result;
+        let response:string = await result;
 
         expect(mockAxios.request).toHaveBeenCalledTimes(1);
         expect(response).toBe(blockchainID);
     });
 
-    test("getBlockchainStatus", async () => {
+    test("getBlockchainStatus", async ()=>{
 
-        let blockchainID: string = "7sik3Pr6r1FeLrvK1oWwECBS8iJ5VPuSh";
-        let result: Promise<string> = platform.getBlockchainStatus(blockchainID);
-        let payload: object = {
+        let blockchainID:string = "7sik3Pr6r1FeLrvK1oWwECBS8iJ5VPuSh";
+        let result:Promise<string> = platform.getBlockchainStatus(blockchainID);
+        let payload:object = {
             "result": {
                 "status": "Accepted"
             }
@@ -113,20 +113,20 @@ describe("Platform", () => {
         };
 
         mockAxios.mockResponse(responseObj);
-        let response: string = await result;
+        let response:string = await result;
 
         expect(mockAxios.request).toHaveBeenCalledTimes(1);
         expect(response).toBe("Accepted");
     });
 
-    test("createAccount 1", async () => {
+    test("createAccount 1", async ()=>{
 
         let address = "deadbeef";
         let privateKey;
         let username = "Robert";
         let password = "Paulson";
-        let result: Promise<string> = platform.createAccount(username, password, privateKey);
-        let payload: object = {
+        let result:Promise<string> = platform.createAccount(username, password, privateKey);
+        let payload:object = {
             "result": {
                 "address": address
             }
@@ -136,20 +136,20 @@ describe("Platform", () => {
         };
 
         mockAxios.mockResponse(responseObj);
-        let response: string = await result;
+        let response:string = await result;
 
         expect(mockAxios.request).toHaveBeenCalledTimes(1);
         expect(response).toBe(address);
     });
 
-    test("createAccount 2", async () => {
+    test("createAccount 2", async ()=>{
 
         let address = "deadbeef";
         let privateKey = "abcdef";
         let username = "Robert";
         let password = "Paulson";
-        let result: Promise<string> = platform.createAccount(username, password, privateKey);
-        let payload: object = {
+        let result:Promise<string> = platform.createAccount(username, password, privateKey);
+        let payload:object = {
             "result": {
                 "address": address
             }
@@ -159,20 +159,20 @@ describe("Platform", () => {
         };
 
         mockAxios.mockResponse(responseObj);
-        let response: string = await result;
+        let response:string = await result;
 
         expect(mockAxios.request).toHaveBeenCalledTimes(1);
         expect(response).toBe(address);
     });
 
-    test("createAccount 3", async () => {
+    test("createAccount 3", async ()=>{
 
         let address = "deadbeef";
         let privateKey = Buffer.from("abcdef", "hex");
         let username = "Robert";
         let password = "Paulson";
-        let result: Promise<string> = platform.createAccount(username, password, privateKey);
-        let payload: object = {
+        let result:Promise<string> = platform.createAccount(username, password, privateKey);
+        let payload:object = {
             "result": {
                 "address": address
             }
@@ -182,22 +182,22 @@ describe("Platform", () => {
         };
 
         mockAxios.mockResponse(responseObj);
-        let response: string = await result;
+        let response:string = await result;
 
         expect(mockAxios.request).toHaveBeenCalledTimes(1);
         expect(response).toBe(address);
     });
 
-    test("getAccount", async () => {
+    test("getAccount", async ()=>{
 
         let address = "deadbeef";
-        let result: Promise<object> = platform.getAccount(address);
+        let result:Promise<object> = platform.getAccount(address);
         let resultobj = {
             "address": address,
             "nonce": "0",
             "balance": "0"
         };
-        let payload: object = {
+        let payload:object = {
             "result": resultobj
         };
         let responseObj = {
@@ -205,13 +205,13 @@ describe("Platform", () => {
         };
 
         mockAxios.mockResponse(responseObj);
-        let response: object = await result;
+        let response:object = await result;
 
         expect(mockAxios.request).toHaveBeenCalledTimes(1);
         expect(response).toBe(resultobj);
     });
 
-    test("exportPrivateKey", async () => {
+    test("exportPrivateKey", async ()=> {
 
         let address = "deadbeef";
         let username = "Robert";
@@ -221,7 +221,7 @@ describe("Platform", () => {
         let resultobj = {
             "privateKey": privateKey
         };
-        let payload: object = {
+        let payload:object = {
             "result": resultobj
         };
         let responseObj = {
@@ -229,13 +229,13 @@ describe("Platform", () => {
         };
 
         mockAxios.mockResponse(responseObj);
-        let response: string = await result;
+        let response:string = await result;
 
         expect(mockAxios.request).toHaveBeenCalledTimes(1);
         expect(response).toBe(privateKey);
     });
 
-    test("importPrivateKey", async () => {
+    test("importPrivateKey", async ()=> {
 
         let address = "deadbeef";
         let username = "Robert";
@@ -245,7 +245,7 @@ describe("Platform", () => {
         let resultobj = {
             "address": address
         };
-        let payload: object = {
+        let payload:object = {
             "result": resultobj
         };
         let responseObj = {
@@ -253,18 +253,17 @@ describe("Platform", () => {
         };
 
         mockAxios.mockResponse(responseObj);
-        let response: string = await result;
+        let response:string = await result;
 
         expect(mockAxios.request).toHaveBeenCalledTimes(1);
         expect(response).toBe(address);
     });
 
-
-    test("listAccounts", async () => {
+    test("listAccounts", async ()=>{
 
         let username = "Robert";
         let password = "Paulson";
-        let result: Promise<object> = platform.listAccounts(username, password);
+        let result:Promise<object> = platform.listAccounts(username, password);
         let accountsArray = [
             {
                 "address": "Q4MzFZZDPHRPAHFeDs3NiyyaZDvxHKivf",
@@ -277,7 +276,7 @@ describe("Platform", () => {
                 "balance": "0"
             }
         ];
-        let payload: object = {
+        let payload:object = {
             "result": {
                 "accounts": accountsArray
             }
@@ -287,16 +286,16 @@ describe("Platform", () => {
         };
 
         mockAxios.mockResponse(responseObj);
-        let response: object = await result;
+        let response:object = await result;
 
         expect(mockAxios.request).toHaveBeenCalledTimes(1);
         expect(response).toBe(accountsArray);
     });
-    test("getCurrentValidators 1", async () => {
+    test("getCurrentValidators 1", async ()=>{
 
         let validators = ['val1', 'val2'];
-        let result: Promise<Array<object>> = platform.getCurrentValidators();
-        let payload: object = {
+        let result:Promise<Array<object>> = platform.getCurrentValidators();
+        let payload:object = {
             "result": {
                 "validators": validators
             }
@@ -306,17 +305,17 @@ describe("Platform", () => {
         };
 
         mockAxios.mockResponse(responseObj);
-        let response: Array<object> = await result;
+        let response:Array<object> = await result;
 
         expect(mockAxios.request).toHaveBeenCalledTimes(1);
         expect(response).toBe(validators);
     });
 
-    test("getCurrentValidators 2", async () => {
-        let subnetID: string = "abcdef"
+    test("getCurrentValidators 2", async ()=>{
+        let subnetID:string = "abcdef"
         let validators = ['val1', 'val2'];
-        let result: Promise<Array<object>> = platform.getCurrentValidators(subnetID);
-        let payload: object = {
+        let result:Promise<Array<object>> = platform.getCurrentValidators(subnetID);
+        let payload:object = {
             "result": {
                 "validators": validators
             }
@@ -326,17 +325,17 @@ describe("Platform", () => {
         };
 
         mockAxios.mockResponse(responseObj);
-        let response: Array<object> = await result;
+        let response:Array<object> = await result;
 
         expect(mockAxios.request).toHaveBeenCalledTimes(1);
         expect(response).toBe(validators);
     });
 
-    test("getCurrentValidators 3", async () => {
-        let subnetID: Buffer = Buffer.from("abcdef", "hex");
+    test("getCurrentValidators 3", async ()=>{
+        let subnetID:Buffer = Buffer.from("abcdef", "hex");
         let validators = ['val1', 'val2'];
-        let result: Promise<Array<object>> = platform.getCurrentValidators(subnetID);
-        let payload: object = {
+        let result:Promise<Array<object>> = platform.getCurrentValidators(subnetID);
+        let payload:object = {
             "result": {
                 "validators": validators
             }
@@ -346,17 +345,17 @@ describe("Platform", () => {
         };
 
         mockAxios.mockResponse(responseObj);
-        let response: Array<object> = await result;
+        let response:Array<object> = await result;
 
         expect(mockAxios.request).toHaveBeenCalledTimes(1);
         expect(response).toBe(validators);
     });
 
-    test("getPendingValidators 1", async () => {
+    test("getPendingValidators 1", async ()=>{
 
         let validators = ['val1', 'val2'];
-        let result: Promise<Array<object>> = platform.getPendingValidators();
-        let payload: object = {
+        let result:Promise<Array<object>> = platform.getPendingValidators();
+        let payload:object = {
             "result": {
                 "validators": validators
             }
@@ -366,17 +365,17 @@ describe("Platform", () => {
         };
 
         mockAxios.mockResponse(responseObj);
-        let response: Array<object> = await result;
+        let response:Array<object> = await result;
 
         expect(mockAxios.request).toHaveBeenCalledTimes(1);
         expect(response).toBe(validators);
     });
 
-    test("getPendingValidators 2", async () => {
-        let subnetID: string = "abcdef"
+    test("getPendingValidators 2", async ()=>{
+        let subnetID:string = "abcdef"
         let validators = ['val1', 'val2'];
-        let result: Promise<Array<object>> = platform.getPendingValidators(subnetID);
-        let payload: object = {
+        let result:Promise<Array<object>> = platform.getPendingValidators(subnetID);
+        let payload:object = {
             "result": {
                 "validators": validators
             }
@@ -386,17 +385,17 @@ describe("Platform", () => {
         };
 
         mockAxios.mockResponse(responseObj);
-        let response: Array<object> = await result;
+        let response:Array<object> = await result;
 
         expect(mockAxios.request).toHaveBeenCalledTimes(1);
         expect(response).toBe(validators);
     });
 
-    test("getPendingValidators 3", async () => {
-        let subnetID: Buffer = Buffer.from("abcdef", "hex");
+    test("getPendingValidators 3", async ()=>{
+        let subnetID:Buffer = Buffer.from("abcdef", "hex");
         let validators = ['val1', 'val2'];
-        let result: Promise<Array<object>> = platform.getPendingValidators(subnetID);
-        let payload: object = {
+        let result:Promise<Array<object>> = platform.getPendingValidators(subnetID);
+        let payload:object = {
             "result": {
                 "validators": validators
             }
@@ -406,17 +405,17 @@ describe("Platform", () => {
         };
 
         mockAxios.mockResponse(responseObj);
-        let response: Array<object> = await result;
+        let response:Array<object> = await result;
 
         expect(mockAxios.request).toHaveBeenCalledTimes(1);
         expect(response).toBe(validators);
     });
 
-    test("sampleValidators 1", async () => {
+    test("sampleValidators 1", async ()=>{
         let subnetID;
         let validators = ['val1', 'val2'];
-        let result: Promise<Array<string>> = platform.sampleValidators(10, subnetID);
-        let payload: object = {
+        let result:Promise<Array<string>> = platform.sampleValidators(10, subnetID);
+        let payload:object = {
             "result": {
                 "validators": validators
             }
@@ -426,17 +425,17 @@ describe("Platform", () => {
         };
 
         mockAxios.mockResponse(responseObj);
-        let response: Array<string> = await result;
+        let response:Array<string> = await result;
 
         expect(mockAxios.request).toHaveBeenCalledTimes(1);
         expect(response).toBe(validators);
     });
 
-    test("sampleValidators 2", async () => {
+    test("sampleValidators 2", async ()=>{
         let subnetID = "abcdef";
         let validators = ['val1', 'val2'];
-        let result: Promise<Array<string>> = platform.sampleValidators(10, subnetID);
-        let payload: object = {
+        let result:Promise<Array<string>> = platform.sampleValidators(10, subnetID);
+        let payload:object = {
             "result": {
                 "validators": validators
             }
@@ -446,18 +445,18 @@ describe("Platform", () => {
         };
 
         mockAxios.mockResponse(responseObj);
-        let response: Array<string> = await result;
+        let response:Array<string> = await result;
 
         expect(mockAxios.request).toHaveBeenCalledTimes(1);
         expect(response).toBe(validators);
     });
 
 
-    test("sampleValidators 3", async () => {
+    test("sampleValidators 3", async ()=>{
         let subnetID = Buffer.from("abcdef", "hex");
         let validators = ['val1', 'val2'];
-        let result: Promise<Array<string>> = platform.sampleValidators(10, subnetID);
-        let payload: object = {
+        let result:Promise<Array<string>> = platform.sampleValidators(10, subnetID);
+        let payload:object = {
             "result": {
                 "validators": validators
             }
@@ -467,23 +466,23 @@ describe("Platform", () => {
         };
 
         mockAxios.mockResponse(responseObj);
-        let response: Array<string> = await result;
+        let response:Array<string> = await result;
 
         expect(mockAxios.request).toHaveBeenCalledTimes(1);
         expect(response).toBe(validators);
     });
 
-    test("addDefaultSubnetValidator 1", async () => {
+    test("addDefaultSubnetValidator 1", async ()=>{
         let id = "abcdef";
-        let startTime = new Date(1985, 5, 9, 12, 59, 43, 9);
-        let endTime = new Date(1982, 3, 1, 12, 58, 33, 7);
+        let startTime = new Date(1985,5,9,12,59,43,9);
+        let endTime = new Date(1982,3,1,12,58,33,7);
         let stakeAmount = new BN(13);
         let payerNonce = 3;
         let destination = "fedcba";
         let delegationFeeRate = new BN(2);
         let utx = "valid";
-        let result: Promise<string> = platform.addDefaultSubnetValidator(id, startTime, endTime, stakeAmount, payerNonce, destination, delegationFeeRate);
-        let payload: object = {
+        let result:Promise<string> = platform.addDefaultSubnetValidator(id, startTime, endTime, stakeAmount, payerNonce, destination, delegationFeeRate);
+        let payload:object = {
             "result": {
                 "unsignedTx": utx
             }
@@ -493,22 +492,22 @@ describe("Platform", () => {
         };
 
         mockAxios.mockResponse(responseObj);
-        let response: string = await result;
+        let response:string = await result;
 
         expect(mockAxios.request).toHaveBeenCalledTimes(1);
         expect(response).toBe(utx);
     });
 
-    test("addNonDefaultSubnetValidator 1", async () => {
+    test("addNonDefaultSubnetValidator 1", async ()=>{
         let id = "abcdef";
         let subnetID;
-        let startTime = new Date(1985, 5, 9, 12, 59, 43, 9);
-        let endTime = new Date(1982, 3, 1, 12, 58, 33, 7);
+        let startTime = new Date(1985,5,9,12,59,43,9);
+        let endTime = new Date(1982,3,1,12,58,33,7);
         let weight = 13;
         let payerNonce = 3;
         let utx = "valid";
-        let result: Promise<string> = platform.addNonDefaultSubnetValidator(id, subnetID, startTime, endTime, weight, payerNonce);
-        let payload: object = {
+        let result:Promise<string> = platform.addNonDefaultSubnetValidator(id, subnetID, startTime, endTime, weight, payerNonce);
+        let payload:object = {
             "result": {
                 "unsignedTx": utx
             }
@@ -518,22 +517,22 @@ describe("Platform", () => {
         };
 
         mockAxios.mockResponse(responseObj);
-        let response: string = await result;
+        let response:string = await result;
 
         expect(mockAxios.request).toHaveBeenCalledTimes(1);
         expect(response).toBe(utx);
     });
 
-    test("addNonDefaultSubnetValidator 2", async () => {
+    test("addNonDefaultSubnetValidator 2", async ()=>{
         let id = "abcdef";
         let subnetID = "abcdef";
-        let startTime = new Date(1985, 5, 9, 12, 59, 43, 9);
-        let endTime = new Date(1982, 3, 1, 12, 58, 33, 7);
+        let startTime = new Date(1985,5,9,12,59,43,9);
+        let endTime = new Date(1982,3,1,12,58,33,7);
         let weight = 13;
         let payerNonce = 3;
         let utx = "valid";
-        let result: Promise<string> = platform.addNonDefaultSubnetValidator(id, subnetID, startTime, endTime, weight, payerNonce);
-        let payload: object = {
+        let result:Promise<string> = platform.addNonDefaultSubnetValidator(id, subnetID, startTime, endTime, weight, payerNonce);
+        let payload:object = {
             "result": {
                 "unsignedTx": utx
             }
@@ -543,22 +542,22 @@ describe("Platform", () => {
         };
 
         mockAxios.mockResponse(responseObj);
-        let response: string = await result;
+        let response:string = await result;
 
         expect(mockAxios.request).toHaveBeenCalledTimes(1);
         expect(response).toBe(utx);
     });
 
-    test("addNonDefaultSubnetValidator 3", async () => {
+    test("addNonDefaultSubnetValidator 3", async ()=>{
         let id = "abcdef";
         let subnetID = Buffer.from("abcdef", "hex");
-        let startTime = new Date(1985, 5, 9, 12, 59, 43, 9);
-        let endTime = new Date(1982, 3, 1, 12, 58, 33, 7);
+        let startTime = new Date(1985,5,9,12,59,43,9);
+        let endTime = new Date(1982,3,1,12,58,33,7);
         let weight = 13;
         let payerNonce = 3;
         let utx = "valid";
-        let result: Promise<string> = platform.addNonDefaultSubnetValidator(id, subnetID, startTime, endTime, weight, payerNonce);
-        let payload: object = {
+        let result:Promise<string> = platform.addNonDefaultSubnetValidator(id, subnetID, startTime, endTime, weight, payerNonce);
+        let payload:object = {
             "result": {
                 "unsignedTx": utx
             }
@@ -568,22 +567,22 @@ describe("Platform", () => {
         };
 
         mockAxios.mockResponse(responseObj);
-        let response: string = await result;
+        let response:string = await result;
 
         expect(mockAxios.request).toHaveBeenCalledTimes(1);
         expect(response).toBe(utx);
     });
 
-    test("addDefaultSubnetDelegator 1", async () => {
+    test("addDefaultSubnetDelegator 1", async ()=>{
         let id = "abcdef";
-        let startTime = new Date(1985, 5, 9, 12, 59, 43, 9);
-        let endTime = new Date(1982, 3, 1, 12, 58, 33, 7);
+        let startTime = new Date(1985,5,9,12,59,43,9);
+        let endTime = new Date(1982,3,1,12,58,33,7);
         let stakeAmount = new BN(13);
         let payerNonce = 3;
         let destination = "fedcba";
         let utx = "valid";
-        let result: Promise<string> = platform.addDefaultSubnetDelegator(id, startTime, endTime, stakeAmount, payerNonce, destination);
-        let payload: object = {
+        let result:Promise<string> = platform.addDefaultSubnetDelegator(id, startTime, endTime, stakeAmount, payerNonce, destination);
+        let payload:object = {
             "result": {
                 "unsignedTx": utx
             }
@@ -593,19 +592,19 @@ describe("Platform", () => {
         };
 
         mockAxios.mockResponse(responseObj);
-        let response: string = await result;
+        let response:string = await result;
 
         expect(mockAxios.request).toHaveBeenCalledTimes(1);
         expect(response).toBe(utx);
     });
 
-    test("createSubnet 1", async () => {
+    test("createSubnet 1", async ()=>{
         let controlKeys = ["abcdef"];
         let threshold = 13;
         let payerNonce = 3;
         let utx = "valid";
-        let result: Promise<string> = platform.createSubnet(controlKeys, threshold, payerNonce);
-        let payload: object = {
+        let result:Promise<string> = platform.createSubnet(controlKeys, threshold, payerNonce);
+        let payload:object = {
             "result": {
                 "unsignedTx": utx
             }
@@ -615,17 +614,17 @@ describe("Platform", () => {
         };
 
         mockAxios.mockResponse(responseObj);
-        let response: string = await result;
+        let response:string = await result;
 
         expect(mockAxios.request).toHaveBeenCalledTimes(1);
         expect(response).toBe(utx);
     });
 
-    test("validatedBy 1", async () => {
+    test("validatedBy 1", async ()=>{
         let blockchainID = "abcdef";
         let resp = "valid";
-        let result: Promise<string> = platform.validatedBy(blockchainID);
-        let payload: object = {
+        let result:Promise<string> = platform.validatedBy(blockchainID);
+        let payload:object = {
             "result": {
                 "subnetID": resp
             }
@@ -635,17 +634,17 @@ describe("Platform", () => {
         };
 
         mockAxios.mockResponse(responseObj);
-        let response: string = await result;
+        let response:string = await result;
 
         expect(mockAxios.request).toHaveBeenCalledTimes(1);
         expect(response).toBe(resp);
     });
 
-    test("validates 1", async () => {
+    test("validates 1", async ()=>{
         let subnetID;
         let resp = ["valid"];
-        let result: Promise<Array<string>> = platform.validates(subnetID);
-        let payload: object = {
+        let result:Promise<Array<string>> = platform.validates(subnetID);
+        let payload:object = {
             "result": {
                 "blockchainIDs": resp
             }
@@ -655,17 +654,17 @@ describe("Platform", () => {
         };
 
         mockAxios.mockResponse(responseObj);
-        let response: Array<string> = await result;
+        let response:Array<string> = await result;
 
         expect(mockAxios.request).toHaveBeenCalledTimes(1);
         expect(response).toBe(resp);
     });
 
-    test("validates 2", async () => {
+    test("validates 2", async ()=>{
         let subnetID = "deadbeef";
         let resp = ["valid"];
-        let result: Promise<Array<string>> = platform.validates(subnetID);
-        let payload: object = {
+        let result:Promise<Array<string>> = platform.validates(subnetID);
+        let payload:object = {
             "result": {
                 "blockchainIDs": resp
             }
@@ -675,17 +674,17 @@ describe("Platform", () => {
         };
 
         mockAxios.mockResponse(responseObj);
-        let response: Array<string> = await result;
+        let response:Array<string> = await result;
 
         expect(mockAxios.request).toHaveBeenCalledTimes(1);
         expect(response).toBe(resp);
     });
 
-    test("validates 3", async () => {
+    test("validates 3", async ()=>{
         let subnetID = Buffer.from("abcdef", "hex");
         let resp = ["valid"];
-        let result: Promise<Array<string>> = platform.validates(subnetID);
-        let payload: object = {
+        let result:Promise<Array<string>> = platform.validates(subnetID);
+        let payload:object = {
             "result": {
                 "blockchainIDs": resp
             }
@@ -695,20 +694,20 @@ describe("Platform", () => {
         };
 
         mockAxios.mockResponse(responseObj);
-        let response: Array<string> = await result;
+        let response:Array<string> = await result;
 
         expect(mockAxios.request).toHaveBeenCalledTimes(1);
         expect(response).toBe(resp);
     });
 
-    test("getBlockchains 1", async () => {
+    test("getBlockchains 1", async ()=>{
         let resp = [{
             "id": "nodeID",
             "subnetID": "subnetID",
             "vmID": "vmID"
         }];
-        let result: Promise<Array<object>> = platform.getBlockchains();
-        let payload: object = {
+        let result:Promise<Array<object>> = platform.getBlockchains();
+        let payload:object = {
             "result": {
                 "blockchains": resp
             }
@@ -718,19 +717,19 @@ describe("Platform", () => {
         };
 
         mockAxios.mockResponse(responseObj);
-        let response: Array<object> = await result;
+        let response:Array<object> = await result;
 
         expect(mockAxios.request).toHaveBeenCalledTimes(1);
         expect(response).toBe(resp);
     });
 
-    test("exportAVA 1", async () => {
+    test("exportAVA 1", async ()=>{
         let amount = new BN(100);
         let to = "abcdef";
         let payerNonce = 3;
         let utx = "valid";
-        let result: Promise<string> = platform.exportAVA(amount, to, payerNonce);
-        let payload: object = {
+        let result:Promise<string> = platform.exportAVA(amount, to, payerNonce);
+        let payload:object = {
             "result": {
                 "unsignedTx": utx
             }
@@ -740,20 +739,20 @@ describe("Platform", () => {
         };
 
         mockAxios.mockResponse(responseObj);
-        let response: string = await result;
+        let response:string = await result;
 
         expect(mockAxios.request).toHaveBeenCalledTimes(1);
         expect(response).toBe(utx);
     });
 
-    test("importAVA 1", async () => {
+    test("importAVA 1", async ()=>{
         let to = "abcdef";
         let payerNonce = 3;
         let username = "Robert";
         let password = "Paulson";
         let tx = "valid";
-        let result: Promise<string> = platform.importAVA(username, password, to, payerNonce);
-        let payload: object = {
+        let result:Promise<string> = platform.importAVA(username, password, to, payerNonce);
+        let payload:object = {
             "result": {
                 "tx": tx
             }
@@ -763,20 +762,20 @@ describe("Platform", () => {
         };
 
         mockAxios.mockResponse(responseObj);
-        let response: string = await result;
+        let response:string = await result;
 
         expect(mockAxios.request).toHaveBeenCalledTimes(1);
         expect(response).toBe(tx);
     });
 
-    test("sign 1", async () => {
+    test("sign 1", async ()=>{
         let utx = "abcdef";
         let signer = "fedcba";
         let username = "Robert";
         let password = "Paulson";
         let tx = "valid";
-        let result: Promise<string> = platform.sign(username, password, utx, signer);
-        let payload: object = {
+        let result:Promise<string> = platform.sign(username, password, utx, signer);
+        let payload:object = {
             "result": {
                 "tx": tx
             }
@@ -786,17 +785,17 @@ describe("Platform", () => {
         };
 
         mockAxios.mockResponse(responseObj);
-        let response: string = await result;
+        let response:string = await result;
 
         expect(mockAxios.request).toHaveBeenCalledTimes(1);
         expect(response).toBe(tx);
     });
 
-    test("issueTx 1", async () => {
+    test("issueTx 1", async ()=>{
         let tx = "abcdef";
         let txID = "valid";
-        let result: Promise<string> = platform.issueTx(tx);
-        let payload: object = {
+        let result:Promise<string> = platform.issueTx(tx);
+        let payload:object = {
             "result": {
                 "txID": txID
             }
@@ -806,20 +805,20 @@ describe("Platform", () => {
         };
 
         mockAxios.mockResponse(responseObj);
-        let response: string = await result;
+        let response:string = await result;
 
         expect(mockAxios.request).toHaveBeenCalledTimes(1);
         expect(response).toBe(txID);
     });
 
-    test("getSubnets 1", async () => {
+    test("getSubnets 1", async ()=>{
         let resp: Array<object> = [{
             "id": "id",
             "controlKeys": ["controlKeys"],
             "threshold": "threshold"
         }];
-        let result: Promise<object> = platform.getSubnets();
-        let payload: object = {
+        let result:Promise<object> = platform.getSubnets();
+        let payload:object = {
             "result": {
                 "subnets": resp
             }
@@ -829,7 +828,7 @@ describe("Platform", () => {
         };
 
         mockAxios.mockResponse(responseObj);
-        let response: object = await result;
+        let response:object = await result;
 
         expect(mockAxios.request).toHaveBeenCalledTimes(1);
         expect(response).toEqual(resp);

--- a/tests/apis/platform/api.test.ts
+++ b/tests/apis/platform/api.test.ts
@@ -1,9 +1,9 @@
 import mockAxios from 'jest-mock-axios';
 
 
-import { Slopes } from "src";
+import {Slopes} from "src";
 import PlatformAPI from "src/apis/platform/api";
-import { Buffer } from "buffer/";
+import {Buffer} from "buffer/";
 import BN from "bn.js";
 import BinTools from 'src/utils/bintools';
 
@@ -20,8 +20,8 @@ describe("Platform", () => {
     let username = 'AvaLabs';
     let password = 'password';
 
-    let slopes = new Slopes(ip,port,protocol, 12345, undefined, true);
-    let platform:PlatformAPI;
+    let slopes = new Slopes(ip, port, protocol, 12345, undefined, true);
+    let platform: PlatformAPI;
 
     beforeAll(() => {
         platform = new PlatformAPI(slopes);
@@ -31,13 +31,13 @@ describe("Platform", () => {
         mockAxios.reset();
     });
 
-    test("createBlockchain 1", async ()=>{
-        let blockchainID:string = "7sik3Pr6r1FeLrvK1oWwECBS8iJ5VPuSh";
-        let vmID:string = "7sik3Pr6r1FeLrvK1oWwECBS8iJ5VPuSh";
-        let name:string = "Some Blockchain";
-        let genesis:string = '{ruh:"roh"}';
-        let result:Promise<string> = platform.createBlockchain(vmID, name, 1, genesis);
-        let payload:object = {
+    test("createBlockchain 1", async () => {
+        let blockchainID: string = "7sik3Pr6r1FeLrvK1oWwECBS8iJ5VPuSh";
+        let vmID: string = "7sik3Pr6r1FeLrvK1oWwECBS8iJ5VPuSh";
+        let name: string = "Some Blockchain";
+        let genesis: string = '{ruh:"roh"}';
+        let result: Promise<string> = platform.createBlockchain(vmID, name, 1, genesis);
+        let payload: object = {
             "result": {
                 "blockchainID": blockchainID
             }
@@ -47,20 +47,20 @@ describe("Platform", () => {
         };
 
         mockAxios.mockResponse(responseObj);
-        let response:string = await result;
+        let response: string = await result;
 
         expect(mockAxios.request).toHaveBeenCalledTimes(1);
         expect(response).toBe(blockchainID);
     });
 
-    test("createBlockchain 2", async ()=>{
-        let blockchainID:string = "7sik3Pr6r1FeLrvK1oWwECBS8iJ5VPuSh";
-        let vmID:string = "7sik3Pr6r1FeLrvK1oWwECBS8iJ5VPuSh";
-        let name:string = "Some Blockchain";
-        let genesis:string = '{ruh:"roh"}';
-        let subnetID:string = "abcdefg";
-        let result:Promise<string> = platform.createBlockchain(vmID, name, 1, genesis, subnetID);
-        let payload:object = {
+    test("createBlockchain 2", async () => {
+        let blockchainID: string = "7sik3Pr6r1FeLrvK1oWwECBS8iJ5VPuSh";
+        let vmID: string = "7sik3Pr6r1FeLrvK1oWwECBS8iJ5VPuSh";
+        let name: string = "Some Blockchain";
+        let genesis: string = '{ruh:"roh"}';
+        let subnetID: string = "abcdefg";
+        let result: Promise<string> = platform.createBlockchain(vmID, name, 1, genesis, subnetID);
+        let payload: object = {
             "result": {
                 "blockchainID": blockchainID
             }
@@ -70,20 +70,20 @@ describe("Platform", () => {
         };
 
         mockAxios.mockResponse(responseObj);
-        let response:string = await result;
+        let response: string = await result;
 
         expect(mockAxios.request).toHaveBeenCalledTimes(1);
         expect(response).toBe(blockchainID);
     });
 
-    test("createBlockchain 3", async ()=>{
-        let blockchainID:string = "7sik3Pr6r1FeLrvK1oWwECBS8iJ5VPuSh";
-        let vmID:string = "7sik3Pr6r1FeLrvK1oWwECBS8iJ5VPuSh";
-        let name:string = "Some Blockchain";
-        let genesis:string = '{ruh:"roh"}';
-        let subnetID:Buffer = Buffer.from("abcdef", "hex");
-        let result:Promise<string> = platform.createBlockchain(vmID, name, 1, genesis, subnetID);
-        let payload:object = {
+    test("createBlockchain 3", async () => {
+        let blockchainID: string = "7sik3Pr6r1FeLrvK1oWwECBS8iJ5VPuSh";
+        let vmID: string = "7sik3Pr6r1FeLrvK1oWwECBS8iJ5VPuSh";
+        let name: string = "Some Blockchain";
+        let genesis: string = '{ruh:"roh"}';
+        let subnetID: Buffer = Buffer.from("abcdef", "hex");
+        let result: Promise<string> = platform.createBlockchain(vmID, name, 1, genesis, subnetID);
+        let payload: object = {
             "result": {
                 "blockchainID": blockchainID
             }
@@ -93,17 +93,17 @@ describe("Platform", () => {
         };
 
         mockAxios.mockResponse(responseObj);
-        let response:string = await result;
+        let response: string = await result;
 
         expect(mockAxios.request).toHaveBeenCalledTimes(1);
         expect(response).toBe(blockchainID);
     });
 
-    test("getBlockchainStatus", async ()=>{
+    test("getBlockchainStatus", async () => {
 
-        let blockchainID:string = "7sik3Pr6r1FeLrvK1oWwECBS8iJ5VPuSh";
-        let result:Promise<string> = platform.getBlockchainStatus(blockchainID);
-        let payload:object = {
+        let blockchainID: string = "7sik3Pr6r1FeLrvK1oWwECBS8iJ5VPuSh";
+        let result: Promise<string> = platform.getBlockchainStatus(blockchainID);
+        let payload: object = {
             "result": {
                 "status": "Accepted"
             }
@@ -113,20 +113,20 @@ describe("Platform", () => {
         };
 
         mockAxios.mockResponse(responseObj);
-        let response:string = await result;
+        let response: string = await result;
 
         expect(mockAxios.request).toHaveBeenCalledTimes(1);
         expect(response).toBe("Accepted");
     });
 
-    test("createAccount 1", async ()=>{
+    test("createAccount 1", async () => {
 
         let address = "deadbeef";
         let privateKey;
         let username = "Robert";
         let password = "Paulson";
-        let result:Promise<string> = platform.createAccount(username, password, privateKey);
-        let payload:object = {
+        let result: Promise<string> = platform.createAccount(username, password, privateKey);
+        let payload: object = {
             "result": {
                 "address": address
             }
@@ -136,20 +136,20 @@ describe("Platform", () => {
         };
 
         mockAxios.mockResponse(responseObj);
-        let response:string = await result;
+        let response: string = await result;
 
         expect(mockAxios.request).toHaveBeenCalledTimes(1);
         expect(response).toBe(address);
     });
 
-    test("createAccount 2", async ()=>{
+    test("createAccount 2", async () => {
 
         let address = "deadbeef";
         let privateKey = "abcdef";
         let username = "Robert";
         let password = "Paulson";
-        let result:Promise<string> = platform.createAccount(username, password, privateKey);
-        let payload:object = {
+        let result: Promise<string> = platform.createAccount(username, password, privateKey);
+        let payload: object = {
             "result": {
                 "address": address
             }
@@ -159,20 +159,20 @@ describe("Platform", () => {
         };
 
         mockAxios.mockResponse(responseObj);
-        let response:string = await result;
+        let response: string = await result;
 
         expect(mockAxios.request).toHaveBeenCalledTimes(1);
         expect(response).toBe(address);
     });
 
-    test("createAccount 3", async ()=>{
+    test("createAccount 3", async () => {
 
         let address = "deadbeef";
         let privateKey = Buffer.from("abcdef", "hex");
         let username = "Robert";
         let password = "Paulson";
-        let result:Promise<string> = platform.createAccount(username, password, privateKey);
-        let payload:object = {
+        let result: Promise<string> = platform.createAccount(username, password, privateKey);
+        let payload: object = {
             "result": {
                 "address": address
             }
@@ -182,22 +182,22 @@ describe("Platform", () => {
         };
 
         mockAxios.mockResponse(responseObj);
-        let response:string = await result;
+        let response: string = await result;
 
         expect(mockAxios.request).toHaveBeenCalledTimes(1);
         expect(response).toBe(address);
     });
 
-    test("getAccount", async ()=>{
+    test("getAccount", async () => {
 
         let address = "deadbeef";
-        let result:Promise<object> = platform.getAccount(address);
+        let result: Promise<object> = platform.getAccount(address);
         let resultobj = {
             "address": address,
             "nonce": "0",
             "balance": "0"
         };
-        let payload:object = {
+        let payload: object = {
             "result": resultobj
         };
         let responseObj = {
@@ -205,18 +205,42 @@ describe("Platform", () => {
         };
 
         mockAxios.mockResponse(responseObj);
-        let response:object = await result;
+        let response: object = await result;
+
+        expect(mockAxios.request).toHaveBeenCalledTimes(1);
+        expect(response).toBe(resultobj);
+    });
+
+    test("exportPrivateKey", async () => {
+
+        let address = "deadbeef";
+        let username = "Robert";
+        let password = "Paulson";
+        let privateKey = "abcdef";
+        let result: Promise<string> = platform.exportKey(username, password, address);
+        let resultobj = {
+            "privateKey": privateKey
+        };
+        let payload: object = {
+            "result": resultobj
+        };
+        let responseObj = {
+            data: payload
+        };
+
+        mockAxios.mockResponse(responseObj);
+        let response: string = await result;
 
         expect(mockAxios.request).toHaveBeenCalledTimes(1);
         expect(response).toBe(resultobj);
     });
 
 
-    test("listAccounts", async ()=>{
+    test("listAccounts", async () => {
 
         let username = "Robert";
         let password = "Paulson";
-        let result:Promise<object> = platform.listAccounts(username, password);
+        let result: Promise<object> = platform.listAccounts(username, password);
         let accountsArray = [
             {
                 "address": "Q4MzFZZDPHRPAHFeDs3NiyyaZDvxHKivf",
@@ -229,7 +253,7 @@ describe("Platform", () => {
                 "balance": "0"
             }
         ];
-        let payload:object = {
+        let payload: object = {
             "result": {
                 "accounts": accountsArray
             }
@@ -239,16 +263,16 @@ describe("Platform", () => {
         };
 
         mockAxios.mockResponse(responseObj);
-        let response:object = await result;
+        let response: object = await result;
 
         expect(mockAxios.request).toHaveBeenCalledTimes(1);
         expect(response).toBe(accountsArray);
     });
-    test("getCurrentValidators 1", async ()=>{
+    test("getCurrentValidators 1", async () => {
 
         let validators = ['val1', 'val2'];
-        let result:Promise<Array<object>> = platform.getCurrentValidators();
-        let payload:object = {
+        let result: Promise<Array<object>> = platform.getCurrentValidators();
+        let payload: object = {
             "result": {
                 "validators": validators
             }
@@ -258,17 +282,17 @@ describe("Platform", () => {
         };
 
         mockAxios.mockResponse(responseObj);
-        let response:Array<object> = await result;
+        let response: Array<object> = await result;
 
         expect(mockAxios.request).toHaveBeenCalledTimes(1);
         expect(response).toBe(validators);
     });
 
-    test("getCurrentValidators 2", async ()=>{
-        let subnetID:string = "abcdef"
+    test("getCurrentValidators 2", async () => {
+        let subnetID: string = "abcdef"
         let validators = ['val1', 'val2'];
-        let result:Promise<Array<object>> = platform.getCurrentValidators(subnetID);
-        let payload:object = {
+        let result: Promise<Array<object>> = platform.getCurrentValidators(subnetID);
+        let payload: object = {
             "result": {
                 "validators": validators
             }
@@ -278,17 +302,17 @@ describe("Platform", () => {
         };
 
         mockAxios.mockResponse(responseObj);
-        let response:Array<object> = await result;
+        let response: Array<object> = await result;
 
         expect(mockAxios.request).toHaveBeenCalledTimes(1);
         expect(response).toBe(validators);
     });
 
-    test("getCurrentValidators 3", async ()=>{
-        let subnetID:Buffer = Buffer.from("abcdef", "hex");
+    test("getCurrentValidators 3", async () => {
+        let subnetID: Buffer = Buffer.from("abcdef", "hex");
         let validators = ['val1', 'val2'];
-        let result:Promise<Array<object>> = platform.getCurrentValidators(subnetID);
-        let payload:object = {
+        let result: Promise<Array<object>> = platform.getCurrentValidators(subnetID);
+        let payload: object = {
             "result": {
                 "validators": validators
             }
@@ -298,17 +322,17 @@ describe("Platform", () => {
         };
 
         mockAxios.mockResponse(responseObj);
-        let response:Array<object> = await result;
+        let response: Array<object> = await result;
 
         expect(mockAxios.request).toHaveBeenCalledTimes(1);
         expect(response).toBe(validators);
     });
 
-    test("getPendingValidators 1", async ()=>{
+    test("getPendingValidators 1", async () => {
 
         let validators = ['val1', 'val2'];
-        let result:Promise<Array<object>> = platform.getPendingValidators();
-        let payload:object = {
+        let result: Promise<Array<object>> = platform.getPendingValidators();
+        let payload: object = {
             "result": {
                 "validators": validators
             }
@@ -318,17 +342,17 @@ describe("Platform", () => {
         };
 
         mockAxios.mockResponse(responseObj);
-        let response:Array<object> = await result;
+        let response: Array<object> = await result;
 
         expect(mockAxios.request).toHaveBeenCalledTimes(1);
         expect(response).toBe(validators);
     });
 
-    test("getPendingValidators 2", async ()=>{
-        let subnetID:string = "abcdef"
+    test("getPendingValidators 2", async () => {
+        let subnetID: string = "abcdef"
         let validators = ['val1', 'val2'];
-        let result:Promise<Array<object>> = platform.getPendingValidators(subnetID);
-        let payload:object = {
+        let result: Promise<Array<object>> = platform.getPendingValidators(subnetID);
+        let payload: object = {
             "result": {
                 "validators": validators
             }
@@ -338,17 +362,17 @@ describe("Platform", () => {
         };
 
         mockAxios.mockResponse(responseObj);
-        let response:Array<object> = await result;
+        let response: Array<object> = await result;
 
         expect(mockAxios.request).toHaveBeenCalledTimes(1);
         expect(response).toBe(validators);
     });
 
-    test("getPendingValidators 3", async ()=>{
-        let subnetID:Buffer = Buffer.from("abcdef", "hex");
+    test("getPendingValidators 3", async () => {
+        let subnetID: Buffer = Buffer.from("abcdef", "hex");
         let validators = ['val1', 'val2'];
-        let result:Promise<Array<object>> = platform.getPendingValidators(subnetID);
-        let payload:object = {
+        let result: Promise<Array<object>> = platform.getPendingValidators(subnetID);
+        let payload: object = {
             "result": {
                 "validators": validators
             }
@@ -358,17 +382,17 @@ describe("Platform", () => {
         };
 
         mockAxios.mockResponse(responseObj);
-        let response:Array<object> = await result;
+        let response: Array<object> = await result;
 
         expect(mockAxios.request).toHaveBeenCalledTimes(1);
         expect(response).toBe(validators);
     });
 
-    test("sampleValidators 1", async ()=>{
+    test("sampleValidators 1", async () => {
         let subnetID;
         let validators = ['val1', 'val2'];
-        let result:Promise<Array<string>> = platform.sampleValidators(10, subnetID);
-        let payload:object = {
+        let result: Promise<Array<string>> = platform.sampleValidators(10, subnetID);
+        let payload: object = {
             "result": {
                 "validators": validators
             }
@@ -378,17 +402,17 @@ describe("Platform", () => {
         };
 
         mockAxios.mockResponse(responseObj);
-        let response:Array<string> = await result;
+        let response: Array<string> = await result;
 
         expect(mockAxios.request).toHaveBeenCalledTimes(1);
         expect(response).toBe(validators);
     });
 
-    test("sampleValidators 2", async ()=>{
+    test("sampleValidators 2", async () => {
         let subnetID = "abcdef";
         let validators = ['val1', 'val2'];
-        let result:Promise<Array<string>> = platform.sampleValidators(10, subnetID);
-        let payload:object = {
+        let result: Promise<Array<string>> = platform.sampleValidators(10, subnetID);
+        let payload: object = {
             "result": {
                 "validators": validators
             }
@@ -398,18 +422,18 @@ describe("Platform", () => {
         };
 
         mockAxios.mockResponse(responseObj);
-        let response:Array<string> = await result;
+        let response: Array<string> = await result;
 
         expect(mockAxios.request).toHaveBeenCalledTimes(1);
         expect(response).toBe(validators);
     });
 
 
-    test("sampleValidators 3", async ()=>{
+    test("sampleValidators 3", async () => {
         let subnetID = Buffer.from("abcdef", "hex");
         let validators = ['val1', 'val2'];
-        let result:Promise<Array<string>> = platform.sampleValidators(10, subnetID);
-        let payload:object = {
+        let result: Promise<Array<string>> = platform.sampleValidators(10, subnetID);
+        let payload: object = {
             "result": {
                 "validators": validators
             }
@@ -419,23 +443,23 @@ describe("Platform", () => {
         };
 
         mockAxios.mockResponse(responseObj);
-        let response:Array<string> = await result;
+        let response: Array<string> = await result;
 
         expect(mockAxios.request).toHaveBeenCalledTimes(1);
         expect(response).toBe(validators);
     });
 
-    test("addDefaultSubnetValidator 1", async ()=>{
+    test("addDefaultSubnetValidator 1", async () => {
         let id = "abcdef";
-        let startTime = new Date(1985,5,9,12,59,43,9);
-        let endTime = new Date(1982,3,1,12,58,33,7);
+        let startTime = new Date(1985, 5, 9, 12, 59, 43, 9);
+        let endTime = new Date(1982, 3, 1, 12, 58, 33, 7);
         let stakeAmount = new BN(13);
         let payerNonce = 3;
         let destination = "fedcba";
         let delegationFeeRate = new BN(2);
         let utx = "valid";
-        let result:Promise<string> = platform.addDefaultSubnetValidator(id, startTime, endTime, stakeAmount, payerNonce, destination, delegationFeeRate);
-        let payload:object = {
+        let result: Promise<string> = platform.addDefaultSubnetValidator(id, startTime, endTime, stakeAmount, payerNonce, destination, delegationFeeRate);
+        let payload: object = {
             "result": {
                 "unsignedTx": utx
             }
@@ -445,22 +469,22 @@ describe("Platform", () => {
         };
 
         mockAxios.mockResponse(responseObj);
-        let response:string = await result;
+        let response: string = await result;
 
         expect(mockAxios.request).toHaveBeenCalledTimes(1);
         expect(response).toBe(utx);
     });
 
-    test("addNonDefaultSubnetValidator 1", async ()=>{
+    test("addNonDefaultSubnetValidator 1", async () => {
         let id = "abcdef";
         let subnetID;
-        let startTime = new Date(1985,5,9,12,59,43,9);
-        let endTime = new Date(1982,3,1,12,58,33,7);
+        let startTime = new Date(1985, 5, 9, 12, 59, 43, 9);
+        let endTime = new Date(1982, 3, 1, 12, 58, 33, 7);
         let weight = 13;
         let payerNonce = 3;
         let utx = "valid";
-        let result:Promise<string> = platform.addNonDefaultSubnetValidator(id, subnetID, startTime, endTime, weight, payerNonce);
-        let payload:object = {
+        let result: Promise<string> = platform.addNonDefaultSubnetValidator(id, subnetID, startTime, endTime, weight, payerNonce);
+        let payload: object = {
             "result": {
                 "unsignedTx": utx
             }
@@ -470,22 +494,22 @@ describe("Platform", () => {
         };
 
         mockAxios.mockResponse(responseObj);
-        let response:string = await result;
+        let response: string = await result;
 
         expect(mockAxios.request).toHaveBeenCalledTimes(1);
         expect(response).toBe(utx);
     });
 
-    test("addNonDefaultSubnetValidator 2", async ()=>{
+    test("addNonDefaultSubnetValidator 2", async () => {
         let id = "abcdef";
         let subnetID = "abcdef";
-        let startTime = new Date(1985,5,9,12,59,43,9);
-        let endTime = new Date(1982,3,1,12,58,33,7);
+        let startTime = new Date(1985, 5, 9, 12, 59, 43, 9);
+        let endTime = new Date(1982, 3, 1, 12, 58, 33, 7);
         let weight = 13;
         let payerNonce = 3;
         let utx = "valid";
-        let result:Promise<string> = platform.addNonDefaultSubnetValidator(id, subnetID, startTime, endTime, weight, payerNonce);
-        let payload:object = {
+        let result: Promise<string> = platform.addNonDefaultSubnetValidator(id, subnetID, startTime, endTime, weight, payerNonce);
+        let payload: object = {
             "result": {
                 "unsignedTx": utx
             }
@@ -495,22 +519,22 @@ describe("Platform", () => {
         };
 
         mockAxios.mockResponse(responseObj);
-        let response:string = await result;
+        let response: string = await result;
 
         expect(mockAxios.request).toHaveBeenCalledTimes(1);
         expect(response).toBe(utx);
     });
 
-    test("addNonDefaultSubnetValidator 3", async ()=>{
+    test("addNonDefaultSubnetValidator 3", async () => {
         let id = "abcdef";
         let subnetID = Buffer.from("abcdef", "hex");
-        let startTime = new Date(1985,5,9,12,59,43,9);
-        let endTime = new Date(1982,3,1,12,58,33,7);
+        let startTime = new Date(1985, 5, 9, 12, 59, 43, 9);
+        let endTime = new Date(1982, 3, 1, 12, 58, 33, 7);
         let weight = 13;
         let payerNonce = 3;
         let utx = "valid";
-        let result:Promise<string> = platform.addNonDefaultSubnetValidator(id, subnetID, startTime, endTime, weight, payerNonce);
-        let payload:object = {
+        let result: Promise<string> = platform.addNonDefaultSubnetValidator(id, subnetID, startTime, endTime, weight, payerNonce);
+        let payload: object = {
             "result": {
                 "unsignedTx": utx
             }
@@ -520,22 +544,22 @@ describe("Platform", () => {
         };
 
         mockAxios.mockResponse(responseObj);
-        let response:string = await result;
+        let response: string = await result;
 
         expect(mockAxios.request).toHaveBeenCalledTimes(1);
         expect(response).toBe(utx);
     });
 
-    test("addDefaultSubnetDelegator 1", async ()=>{
+    test("addDefaultSubnetDelegator 1", async () => {
         let id = "abcdef";
-        let startTime = new Date(1985,5,9,12,59,43,9);
-        let endTime = new Date(1982,3,1,12,58,33,7);
+        let startTime = new Date(1985, 5, 9, 12, 59, 43, 9);
+        let endTime = new Date(1982, 3, 1, 12, 58, 33, 7);
         let stakeAmount = new BN(13);
         let payerNonce = 3;
         let destination = "fedcba";
         let utx = "valid";
-        let result:Promise<string> = platform.addDefaultSubnetDelegator(id, startTime, endTime, stakeAmount, payerNonce, destination);
-        let payload:object = {
+        let result: Promise<string> = platform.addDefaultSubnetDelegator(id, startTime, endTime, stakeAmount, payerNonce, destination);
+        let payload: object = {
             "result": {
                 "unsignedTx": utx
             }
@@ -545,19 +569,19 @@ describe("Platform", () => {
         };
 
         mockAxios.mockResponse(responseObj);
-        let response:string = await result;
+        let response: string = await result;
 
         expect(mockAxios.request).toHaveBeenCalledTimes(1);
         expect(response).toBe(utx);
     });
 
-    test("createSubnet 1", async ()=>{
+    test("createSubnet 1", async () => {
         let controlKeys = ["abcdef"];
         let threshold = 13;
         let payerNonce = 3;
         let utx = "valid";
-        let result:Promise<string> = platform.createSubnet(controlKeys, threshold, payerNonce);
-        let payload:object = {
+        let result: Promise<string> = platform.createSubnet(controlKeys, threshold, payerNonce);
+        let payload: object = {
             "result": {
                 "unsignedTx": utx
             }
@@ -567,17 +591,17 @@ describe("Platform", () => {
         };
 
         mockAxios.mockResponse(responseObj);
-        let response:string = await result;
+        let response: string = await result;
 
         expect(mockAxios.request).toHaveBeenCalledTimes(1);
         expect(response).toBe(utx);
     });
 
-    test("validatedBy 1", async ()=>{
+    test("validatedBy 1", async () => {
         let blockchainID = "abcdef";
         let resp = "valid";
-        let result:Promise<string> = platform.validatedBy(blockchainID);
-        let payload:object = {
+        let result: Promise<string> = platform.validatedBy(blockchainID);
+        let payload: object = {
             "result": {
                 "subnetID": resp
             }
@@ -587,17 +611,17 @@ describe("Platform", () => {
         };
 
         mockAxios.mockResponse(responseObj);
-        let response:string = await result;
+        let response: string = await result;
 
         expect(mockAxios.request).toHaveBeenCalledTimes(1);
         expect(response).toBe(resp);
     });
 
-    test("validates 1", async ()=>{
+    test("validates 1", async () => {
         let subnetID;
         let resp = ["valid"];
-        let result:Promise<Array<string>> = platform.validates(subnetID);
-        let payload:object = {
+        let result: Promise<Array<string>> = platform.validates(subnetID);
+        let payload: object = {
             "result": {
                 "blockchainIDs": resp
             }
@@ -607,17 +631,17 @@ describe("Platform", () => {
         };
 
         mockAxios.mockResponse(responseObj);
-        let response:Array<string> = await result;
+        let response: Array<string> = await result;
 
         expect(mockAxios.request).toHaveBeenCalledTimes(1);
         expect(response).toBe(resp);
     });
 
-    test("validates 2", async ()=>{
+    test("validates 2", async () => {
         let subnetID = "deadbeef";
         let resp = ["valid"];
-        let result:Promise<Array<string>> = platform.validates(subnetID);
-        let payload:object = {
+        let result: Promise<Array<string>> = platform.validates(subnetID);
+        let payload: object = {
             "result": {
                 "blockchainIDs": resp
             }
@@ -627,17 +651,17 @@ describe("Platform", () => {
         };
 
         mockAxios.mockResponse(responseObj);
-        let response:Array<string> = await result;
+        let response: Array<string> = await result;
 
         expect(mockAxios.request).toHaveBeenCalledTimes(1);
         expect(response).toBe(resp);
     });
 
-    test("validates 3", async ()=>{
+    test("validates 3", async () => {
         let subnetID = Buffer.from("abcdef", "hex");
         let resp = ["valid"];
-        let result:Promise<Array<string>> = platform.validates(subnetID);
-        let payload:object = {
+        let result: Promise<Array<string>> = platform.validates(subnetID);
+        let payload: object = {
             "result": {
                 "blockchainIDs": resp
             }
@@ -647,20 +671,20 @@ describe("Platform", () => {
         };
 
         mockAxios.mockResponse(responseObj);
-        let response:Array<string> = await result;
+        let response: Array<string> = await result;
 
         expect(mockAxios.request).toHaveBeenCalledTimes(1);
         expect(response).toBe(resp);
     });
 
-    test("getBlockchains 1", async ()=>{
+    test("getBlockchains 1", async () => {
         let resp = [{
             "id": "nodeID",
             "subnetID": "subnetID",
             "vmID": "vmID"
         }];
-        let result:Promise<Array<object>> = platform.getBlockchains();
-        let payload:object = {
+        let result: Promise<Array<object>> = platform.getBlockchains();
+        let payload: object = {
             "result": {
                 "blockchains": resp
             }
@@ -670,19 +694,19 @@ describe("Platform", () => {
         };
 
         mockAxios.mockResponse(responseObj);
-        let response:Array<object> = await result;
+        let response: Array<object> = await result;
 
         expect(mockAxios.request).toHaveBeenCalledTimes(1);
         expect(response).toBe(resp);
     });
 
-    test("exportAVA 1", async ()=>{
+    test("exportAVA 1", async () => {
         let amount = new BN(100);
         let to = "abcdef";
         let payerNonce = 3;
         let utx = "valid";
-        let result:Promise<string> = platform.exportAVA(amount, to, payerNonce);
-        let payload:object = {
+        let result: Promise<string> = platform.exportAVA(amount, to, payerNonce);
+        let payload: object = {
             "result": {
                 "unsignedTx": utx
             }
@@ -692,20 +716,20 @@ describe("Platform", () => {
         };
 
         mockAxios.mockResponse(responseObj);
-        let response:string = await result;
+        let response: string = await result;
 
         expect(mockAxios.request).toHaveBeenCalledTimes(1);
         expect(response).toBe(utx);
     });
 
-    test("importAVA 1", async ()=>{
+    test("importAVA 1", async () => {
         let to = "abcdef";
         let payerNonce = 3;
         let username = "Robert";
         let password = "Paulson";
         let tx = "valid";
-        let result:Promise<string> = platform.importAVA(username, password, to, payerNonce);
-        let payload:object = {
+        let result: Promise<string> = platform.importAVA(username, password, to, payerNonce);
+        let payload: object = {
             "result": {
                 "tx": tx
             }
@@ -715,20 +739,20 @@ describe("Platform", () => {
         };
 
         mockAxios.mockResponse(responseObj);
-        let response:string = await result;
+        let response: string = await result;
 
         expect(mockAxios.request).toHaveBeenCalledTimes(1);
         expect(response).toBe(tx);
     });
 
-    test("sign 1", async ()=>{
+    test("sign 1", async () => {
         let utx = "abcdef";
         let signer = "fedcba";
         let username = "Robert";
         let password = "Paulson";
         let tx = "valid";
-        let result:Promise<string> = platform.sign(username, password, utx, signer);
-        let payload:object = {
+        let result: Promise<string> = platform.sign(username, password, utx, signer);
+        let payload: object = {
             "result": {
                 "tx": tx
             }
@@ -738,17 +762,17 @@ describe("Platform", () => {
         };
 
         mockAxios.mockResponse(responseObj);
-        let response:string = await result;
+        let response: string = await result;
 
         expect(mockAxios.request).toHaveBeenCalledTimes(1);
         expect(response).toBe(tx);
     });
 
-    test("issueTx 1", async ()=>{
+    test("issueTx 1", async () => {
         let tx = "abcdef";
         let txID = "valid";
-        let result:Promise<string> = platform.issueTx(tx);
-        let payload:object = {
+        let result: Promise<string> = platform.issueTx(tx);
+        let payload: object = {
             "result": {
                 "txID": txID
             }
@@ -758,20 +782,20 @@ describe("Platform", () => {
         };
 
         mockAxios.mockResponse(responseObj);
-        let response:string = await result;
+        let response: string = await result;
 
         expect(mockAxios.request).toHaveBeenCalledTimes(1);
         expect(response).toBe(txID);
     });
 
-    test("getSubnets 1", async ()=>{
+    test("getSubnets 1", async () => {
         let resp: Array<object> = [{
             "id": "id",
             "controlKeys": ["controlKeys"],
             "threshold": "threshold"
         }];
-        let result:Promise<object> = platform.getSubnets();
-        let payload:object = {
+        let result: Promise<object> = platform.getSubnets();
+        let payload: object = {
             "result": {
                 "subnets": resp
             }
@@ -781,7 +805,7 @@ describe("Platform", () => {
         };
 
         mockAxios.mockResponse(responseObj);
-        let response:object = await result;
+        let response: object = await result;
 
         expect(mockAxios.request).toHaveBeenCalledTimes(1);
         expect(response).toEqual(resp);

--- a/tests/apis/platform/api.test.ts
+++ b/tests/apis/platform/api.test.ts
@@ -232,7 +232,31 @@ describe("Platform", () => {
         let response: string = await result;
 
         expect(mockAxios.request).toHaveBeenCalledTimes(1);
-        expect(response).toBe(resultobj);
+        expect(response).toBe(privateKey);
+    });
+
+    test("importPrivateKey", async () => {
+
+        let address = "deadbeef";
+        let username = "Robert";
+        let password = "Paulson";
+        let privateKey;
+        let result: Promise<string> = platform.importKey(username, password, privateKey);
+        let resultobj = {
+            "address": address
+        };
+        let payload: object = {
+            "result": resultobj
+        };
+        let responseObj = {
+            data: payload
+        };
+
+        mockAxios.mockResponse(responseObj);
+        let response: string = await result;
+
+        expect(mockAxios.request).toHaveBeenCalledTimes(1);
+        expect(response).toBe(address);
     });
 
 


### PR DESCRIPTION
This PR contains : 

- [ ] Add `exportKey` function in PlatformAPI . (https://docs.ava.network/v1.0/en/api/platform/#platformexportkey)
- [ ] Add `importKey` function in PlatformAPI . (https://docs.ava.network/v1.0/en/api/platform/#platformimportkey)
- [ ] Add tests for those calls